### PR TITLE
Add workaround for missing UI.WorldToScreen method in SHVDNv2/3 combined releases

### DIFF
--- a/MapInfoTool/src/ScriptBase/Entity Info/BaseObjectInfo.cs
+++ b/MapInfoTool/src/ScriptBase/Entity Info/BaseObjectInfo.cs
@@ -85,7 +85,7 @@ namespace MapInfoTool.ScriptBase.Entity_Info
         {
             get
             {
-                var screenPos = UI.WorldToScreen(MidPoint);
+                var screenPos = Utility.WorldToScreen(MidPoint);
                 return screenPos.X != 0 && screenPos.Y != 0;
             }
         }

--- a/MapInfoTool/src/Utility.cs
+++ b/MapInfoTool/src/Utility.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Reflection;
 using GTA;
+using GTA.Math;
+using GTA.Native;
 
 namespace MapInfoTool
 {
@@ -32,5 +34,12 @@ namespace MapInfoTool
             return Game.GenerateHash(text);
         }
 
+        public static Vector2 WorldToScreen(Vector3 pos)
+        {
+            var x2dp = new OutputArgument();
+            var y2dp = new OutputArgument();
+            Function.Call<bool>(Hash._WORLD3D_TO_SCREEN2D, pos.X, pos.Y, pos.Z, x2dp, y2dp);
+            return new Vector2(x2dp.GetResult<float>(), y2dp.GetResult<float>());
+        }
     }
 }


### PR DESCRIPTION
A quick workaround to get it working again. I left the other stuff as-is, if you still have the old SHVDN2 laying about, otherwise an update to 4.8 is needed if compiled against the newest version (or the Nuget package).